### PR TITLE
[25, 26장] 클래스, ES6

### DIFF
--- a/25장 클래스/25장_최은형.md
+++ b/25장 클래스/25장_최은형.md
@@ -1,0 +1,299 @@
+### 25.2 클래스 정의
+
+---
+
+클래스는 표현식으로 정의할 수 있다(일급 객체다)
+
+```jsx
+const Person = class {};
+const Person = class MyClass {};
+```
+
+- 무명 리터럴 가능(런타임에 생성 가능)
+- 변수나 자료구조에 저장 가능
+- 함수 매개변수로 전달 가능
+- 함수 반환값으로 사용 가능
+
+⇒ 클래스는 함수다
+
+클래스에서 정의할 수 있는 메서드
+
+1. constructor
+2. 프로토타입 메서드(일반)
+3. 정적 메서드(static)
+
+### 25.3 클래스 호이스팅
+
+---
+
+typeof Person === function
+
+- 클래스 정의 이전에는 참조할 수 없음
+- 그렇다고 호이스팅이 되지 않는 것은 아님. like `let` `const`
+
+### 25.5 메서드
+
+---
+
+console.dir(Person)
+
+![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/719ef110-29bc-4a6a-91c0-ea84d151d59b/fce3af3a-b42c-4ad0-8219-d88087bccd7a/image.png)
+
+- prototype 프로퍼티가 가리키는 프로토타입 객체의 constructor 프로퍼티는 클래스 자신을 가리키고 있다
+
+  = 클래스는 인스턴스를 생성하는 생성자 함수다
+
+  → 그래서 new 연산자로 인스턴스가 생성되는 것
+
+- constructor 내부의 this는 (생성자 함수와 마찬가지로) 클래스가 생성한 인스턴스를 가리킨다
+
+    ```jsx
+    class Person {
+    	constructor(name) {
+    		this.name = name;
+    	}
+    }
+    
+    function Person(name) {
+    	this.name = name;
+    }
+    ```
+
+
+constructor가 클래스나 인스턴스에 없는 이유? ( ≠ 프로토타입 construct 와 다름! )
+
+- constructor는 메서드가 아니라 함수 객체 코드의 일부가 되기 때문
+- 인스턴스를 초기화하려면 constructor를 생략해선 안된다
+- 반환문을 갖지 않아야 함(암묵적으로 this를 반환하고 있기 때문)
+
+프로토타입 메서드
+
+- 클래스가 생성한 인스턴스는 프로토타입 체인의 일원이 된다
+
+  `me instanceof Person; // true`
+
+  `me instanceof Object; // true`
+
+- 프로토타입 체인은 클래스에 의해 생성된 인스턴스에도 동일하게 적용
+- 클래스는 프로토타입 기반의 객체 생성 메커니즘이다
+
+정적 메서드
+
+![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/719ef110-29bc-4a6a-91c0-ea84d151d59b/f9890744-af1c-4d62-b133-db74f8f373d0/image.png)
+
+- 클래스 몸체에서 정의한 메서드는 프로토타입 메서드가 된다
+- 정적 메서드는 클래스에 바인딩된 메서드가 된다
+- 정적 메서드는 인스턴스 프로퍼티를 참조할 수 없다
+- 정적 메서드 내부의 this = 인스턴스 X. 클래스 O
+    - **this를 사용하지 않는 메서드는 정적 메서드로 정의**
+- 정적 메서드의 장점: 네임스페이스, 유틸리티 함수
+
+### 25.6 클래스의 인스턴스 생성 과정
+
+---
+
+new → 내부 메서드 [[Construct]] 호출 → 인스턴스 생성과 this 바인딩 → 인스턴스 초기화 → 인스턴스 반환
+
+```jsx
+class Person {
+	constructor(name) {
+		// 1. 암묵적으로 인스턴스가 생성되고 this에 바인딩
+		console.log(this); // Person {}
+		console.log(Object.getPrototypeOf(this) === Person.prototype); // true
+		
+		// 2. this에 바인딩되어 있는 인스턴스 초기화
+		this.name = name;
+		
+		// 3. 완성된 인스턴스가 바인딩된 this 암묵적으로 반환
+	}
+}
+```
+
+### 25.7 프로퍼티
+
+---
+
+constructor 내부에서 정의하면 인스턴스 프로퍼티가 됨
+
+클래스에서 접근자 프로퍼티 사용하는 방법
+
+```jsx
+class Person {
+	...
+	get fullName() { ... }
+	set fullName(name) { ... }
+}
+
+me.fullName = 'Eunhyung Choi'; // 접근자 프로퍼티를 통한 값 저장
+console.log(me.fullName); // 접근자 프로퍼티를 통한 값 참조
+```
+
+- 접근자 프로퍼티도 프로토타입의 프로퍼티가 된다
+
+클래스 필드 정의 제안
+
+- `클래스 필드` 클래스가 생성할 인스턴스의 프로퍼티
+- JS는 몸체에 메서드만 선언 가능
+
+  → 최신 브라우저, node부터는 클래스 필드를 몸체에 정의할 수 있음
+
+
+```jsx
+class Person {
+	name = 'Lee'; // 미할당 시 undefined.
+	this.name = ''; // X. this는 constructor와 메서드 내에서만 유효
+	
+	constructor() {
+		console.log(name); // X. 클래스 필드 참조 시 반드시 this 사용
+	}
+}
+```
+
+private 필드 정의 제안
+
+`#privateField`
+
+```jsx
+class Person {
+	#name = ''; // 반드시 몸체에 선언
+	
+	constructor(name) {
+		this.#name = name; // 참조할 때도 #를 붙여야함
+	}
+}
+
+const me = new Person('Lee');
+console.log(me.#name); // SyntaxError...
+```
+
+- 타입스크립트를 사용할 경우 public, private, protected를 모두 사용할 수 있다
+- 접근자 프로퍼티를 사용하면 private 참조 가능
+
+static 필드 정의 제안
+
+`static public 필드` `static private 필드` `static private 메서드`
+
+```jsx
+class MyMath {
+	static PI = 22 / 7; // static public 필드
+	
+	static #num = 10; // static private
+	
+	static increment() { // satic 메서드
+		return ++MyMath.#num;
+	}
+}
+```
+
+### 25.8 상속에 의한 클래스 확장
+
+---
+
+extends
+
+- 수퍼클래스와 서브클래스는 `인스턴스 프로토타입 체인` & `클래스 간 프로토타입 체인` 도 생성한다
+- 프로토타입 메서드, 정적 메서드 모두 상속 가능
+
+동적 상속
+
+- class 클래스 extends 생성자함수
+- class 클래스 extends **(condition ? Base1 : Base2)** {}
+
+서브 클래스의 constructor
+
+- 생략하면 암묵적으로 constructor(…args) { super(…args); } 정의
+
+super 키워드
+
+- super는 호출&**참조**가 가능하다
+
+    ```jsx
+    class Base {
+    	constructor(name) {
+    		this.name = name;
+    	}
+    	sayHi() {
+    		return `Hi! ${this.name}`;
+    	}
+    }
+    
+    class Derived extends Base {
+    	sayHi() {
+    		return super.sayHi();
+    	}
+    }
+    
+    // 아래와 동일(수퍼클래스의 prototype 프로퍼티에 바인딩된 프로토타입을 참조할 수 있어야 함)
+    
+    class Derived extends Base {
+    	sayHi() {
+    		const __super = Object.getPrototypeOf(Derived.prototype);
+    		return __super.sayHi.call(this); // 바인딩을 해야 인스턴스의 this가 들어감
+    	}
+    }
+    ```
+
+- 주의사항
+    - 서브클래스 constructor가 선언될 경우 반드시 super 있어야 함
+    - super 호출 전에는 this 참조 불가
+    - super를 일반 클래스는 호출 불가
+- super는 자신을 참조하고 있는 메서드가 바인딩되어 있는 객체의 프로토타입을 가리킨다
+    - Derived > sayHi가 바인딩된 Derived.prototype의 프로토타입 = Base.prototype
+    - super.sayHi === Base.prototype.sayHi
+- **[[HomeObject]]**
+    - 메서드 자신을 바인딩하고 있는 객체
+    - Derived > sayHi의 [[HomeObject]]는 Derived.prototype이다
+
+      → [[HomeObject]]의 프로토타입은 Base.prototype이다 === super
+
+    - 단, ES6 메서드 축약 표현일 때만 사용 가능
+        - 이때는 객체 리터럴에서도 super 참조 사용 가능
+
+    ```jsx
+    const base = {
+    	name: 'Lee',
+    	sayHi() {
+    		return `Hi ${this.name}`;
+    	}
+    }
+    
+    const derived = {
+    	__proto__: base,
+    	sayHi() { // ES6 메서드 축약 표현으로 정의한 메서드
+    		return `${super.sayHi()}. how are you doing?`;
+    	}
+    }
+    ```
+
+- 서브 클래스 > 정적 메서드 내에서의 super.sayHi는 수퍼 클래스의 정적 메서드 sayHi를 가리킨다
+
+상속 클래스의 인스턴스 생성 과정
+
+1. 수퍼냐 서브냐에 따라 [[ConstructorKind]] 값이 “base”/”derived”로 나뉜다, super 실행
+2. 암묵적으로 빈 객체(인스턴스) 생성 후 this 바인딩
+    - this === 인스턴스
+    - new.target === new 연산자와 함께 호출된 함수
+3. 수퍼클래스 constructor 실행 및 this 초기화
+4. 서브클래스 constructor로 복귀, super가 반환한 인스턴스가 this에 바인딩
+5. this에 바인딩되어 있는 인스턴스 초기화
+6. 인스턴스 암묵적 반환
+
+표준 빌트인 생성자 함수 확장
+
+- **String, Number 같은 표준 빌트인 객체도 확장할 수 있다**
+
+    ```jsx
+    class MyArray extends Array { ... };
+    
+    const myArray = new MyArray(...); // MyArray 인스턴스는 Array.prototype과 MyArray.prototype의 모든 메서드 사용 가능
+    ```
+
+- 메서드 체이닝(ex. arr.filte.map.average)이 가능하게 하려면 Array가 생성한 인스턴스를 반환하게 해야함
+
+    ```jsx
+    class MyArray extends Array {
+    	// 모든 메서드가 Array 타입의 인스턴스를 반환하도록 한다
+    	static get [Symbol.species]() { return Array; }
+    	...
+    }
+    ```

--- a/26장 ES6 함수의 추가 기능/26장_최은형.md
+++ b/26장 ES6 함수의 추가 기능/26장_최은형.md
@@ -1,0 +1,64 @@
+### 26.1 함수의 구분
+
+---
+
+ES6 이후
+
+- 이전에는 함수가 callable하면서 constructor이었다
+- 이후 부터는 사용 목적에 따라 세 종류로 구분
+
+
+    |  | constructor | prototype | super | arguments |
+    | --- | --- | --- | --- | --- |
+    | 일반 함수 | O | O | X | O |
+    | 메서드 | **X** | X | O | O |
+    | 화살표 함수 | **X** | X | X | X |
+
+### 26.2 메서드
+
+---
+
+ES6 메서드
+
+- 단순히 객체에 바인딩된 함수 X. 메서드 축약표현으로 정의된 함수 only
+
+    ```jsx
+    const obj = {
+    	x: 1,
+    	foo() { return this.x }, // O
+    	bar: function() { ... }, // X
+    }
+    ```
+
+- non-constructor로, 인스턴스 생성 불가 → **prototype 프로퍼티도 없고 프로토타입도 생성하지 않음**
+- 표준 빌트인 객체의 메서드들도 전부 non-con
+- [[HomeObject]]를 갖는다 → **super 키워드를 사용할 수 있다**
+
+    ```jsx
+    const base = { ... }
+    const derived = {
+    	__proto__: base,
+    	sayHi() {
+    		return super.sayHi();
+    	}
+    }
+    ```
+
+
+### 26.3 화살표 함수
+
+---
+
+콜백 함수 내부에서 this가 전역 객체를 가리키는 문제를 해결하기 위한 대안으로 유용
+
+화살표 함수 vs 일반 함수
+
+- 화살표 함수는 행성자 함수로서 호출할 수 없다 → 인스턴스 생성 불가 → prototype 프로퍼티, 프로토타입 X
+- 중복 매개변수 불가
+- 자체 this, arguments, super, [new.targe](http://new.target)t 바인딩 X → 무조건 상위 스코프 참조
+
+this
+
+- **Lexical this** 화살표 함수 내부에서 this를 참조하면 상위 스코프의 this를 그대로 참조한다
+- 화살표 함수가 중첩되어있다면 스코프 체인 상에서 가장 가까운 상위 함수 중 화살표 함수가 아닌 함수의 this를 참조
+- this 자체가 없기 때문에 apply나 bind로 this 교체 불가능


### PR DESCRIPTION
## 📌 변경된 내용
- resolved: #50 
- resolved: #51 

## 📌 기타 의견, 응용력 기르기
클래스
- this를 사용하지 않는 메서드는 정적 메서드로 정의해야한다
- extends ( condition ? Class1 : Class2 ) {}  이런식의 동적 상속은 처음본다. 유용하게 쓸 수 있을 것 같다.
- String, Number 같은 표준 빌트인 객체 확장
- 너무 생성자 함수 설명의 비중이 많지 않았나 생각했다

ES6
- [[HomeObject]]를 갖는다 → super 키워드를 사용할 수 있다


<br/>
## 📌 본문
